### PR TITLE
Fix Marionette dependency name, assign to Marionette, and export 'Marionette.Component'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,9 +28,9 @@ gulp.task('wrap', function() {
   return gulp.src(srcFile)
     .pipe(wrap({
       namespace: 'Marionette.Component',
-      exports: 'Component',
+      exports: 'Marionette.Component',
       deps: [
-        { name: 'marionette', globalName: 'Marionette', paramName: 'Marionette' }
+        { name: 'backbone.marionette', globalName: 'Marionette', paramName: 'Marionette' }
       ]
     }))
     .pipe(gulp.dest(distPath));
@@ -89,7 +89,7 @@ gulp.task('buildTestLib', function() {
   return gulp.src(srcFile)
     .pipe(wrap({
       namespace: 'Marionette.Component',
-      exports: 'Component'
+      exports: 'Marionette.Component'
     }))
     .pipe(gulp.dest('spec/support'));
 });

--- a/src/marionette.component.js
+++ b/src/marionette.component.js
@@ -7,7 +7,7 @@
 // Marionette.Component can optionally have a `region`, `model`,
 // and/or `collection` passed to it through the constructor options.
 
-var Component = Marionette.Controller.extend({
+Marionette.Component = Marionette.Controller.extend({
   constructor: function(options) {
     options = options || {};
 


### PR DESCRIPTION
Fixes #15.
