### PR TITLE
Update backbone.marionette version to 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chai-jq": "0.0.7"
   },
   "dependencies": {
-    "backbone.marionette": "~2.1.0",
+    "backbone.marionette": "^2.4.4",
     "backbone": "1.0.0 - 1.1.2",
     "underscore": "1.4.4 - 1.6.0"
   }


### PR DESCRIPTION
We're getting issues with getChildView being undefined in 2.1.0 version of backbone.marionette. It was resolved in Backbone.marionette 2.4.4
